### PR TITLE
Export types

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -26,10 +26,10 @@
   },
   "typesVersions": {
     "*": {
-      "bundles": [
+      "bundles.js": [
         "dist/bundles.d.ts"
       ],
-      "dat": [
+      "dat.js": [
         "dist/dat.d.ts"
       ]
     }

--- a/lib/package.json
+++ b/lib/package.json
@@ -23,5 +23,15 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "typesVersions": {
+    "*": {
+      "bundles": [
+        "dist/bundles.d.ts"
+      ],
+      "dat": [
+        "dist/dat.d.ts"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Added exporting of types to use the library in typescript projects (as a dependency)

You can recreate the error by doing `npm i pathofexile-dat` in typescript project
<img width="944" alt="image" src="https://github.com/SnosMe/poe-dat-viewer/assets/1833969/f0d32317-f365-40f8-82ec-4083d22194f7">
