### PR TITLE
Treat 0xFE as null in 16-byte references

### DIFF
--- a/lib/src/dat-analysis/analysis.zig
+++ b/lib/src/dat-analysis/analysis.zig
@@ -57,8 +57,8 @@ fn analyzeDat(
 ) void {
   const kPtrSize = @sizeOf(SizeT);
   const kPtrSize_2 = @sizeOf(SizeT) * 2;
-  const kNull = if (@sizeOf(SizeT) == 4) 0xFEFEFEFE else 0xFEFEFEFEFEFEFEFE;
-  const kZero = if (@sizeOf(SizeT) == 4) 0x00000000 else 0x0000000000000000;
+  const kNull = if (@sizeOf(SizeT) == 4) 0xFEFEFEFE else if (@sizeOf(SizeT) == 8) 0xFEFEFEFEFEFEFEFE else 0xFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFE;
+  const kZero = if (@sizeOf(SizeT) == 4) 0x00000000 else if (@sizeOf(SizeT) == 8) 0x0000000000000000 else 0x00000000000000000000000000000000;
   const kNullStart = 0xFE;
   const kStrTerminatorSize = 4;
   const rowLength = stats.len;


### PR DESCRIPTION
Some columns are 16-byte long (e.g. Stats in `mods` table or yet unknonwn column in `passiveskills`), the analysis module should not reject to mark them as references if a value of 16 bytes of 0xFE is found