### PR TITLE
fix(lib): Fetch latest schema package at build time 

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "pathofexile-dat",
-  "version": "13.0.0",
-  "type": "module",
-  "bin": "./dist/cli/run.js",
-  "exports": {
-    "./bundles.js": "./dist/bundles.js",
-    "./dat.js": "./dist/dat.js"
-  },
-  "files": ["dist/**/*"],
-  "license": "MIT",
-  "repository": {
-    "url": "https://github.com/SnosMe/poe-dat-viewer"
-  },
-  "dependencies": {
-    "ooz-wasm": "^2.0.0",
-    "pathofexile-dat-schema": "^7.0.0"
-  },
-  "devDependencies": {
-    "@types/node": "^18.0.0",
-    "typescript": "^5.2.0"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  }
+	"name": "pathofexile-dat",
+	"version": "13.0.0",
+	"type": "module",
+	"bin": "./dist/cli/run.js",
+	"exports": {
+		"./bundles.js": "./dist/bundles.js",
+		"./dat.js": "./dist/dat.js"
+	},
+	"files": ["dist/**/*"],
+	"license": "MIT",
+	"repository": {
+		"url": "https://github.com/SnosMe/poe-dat-viewer"
+	},
+	"dependencies": {
+		"ooz-wasm": "^2.0.0",
+		"pathofexile-dat-schema": "latest"
+	},
+	"devDependencies": {
+		"@types/node": "^18.0.0",
+		"typescript": "^5.2.0"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	}
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "pathofexile-dat",
-	"version": "13.0.0",
-	"type": "module",
-	"bin": "./dist/cli/run.js",
-	"exports": {
-		"./bundles.js": "./dist/bundles.js",
-		"./dat.js": "./dist/dat.js"
-	},
-	"files": ["dist/**/*"],
-	"license": "MIT",
-	"repository": {
-		"url": "https://github.com/SnosMe/poe-dat-viewer"
-	},
-	"dependencies": {
-		"ooz-wasm": "^2.0.0",
-		"pathofexile-dat-schema": "latest"
-	},
-	"devDependencies": {
-		"@types/node": "^18.0.0",
-		"typescript": "^5.2.0"
-	},
-	"engines": {
-		"node": ">=18.0.0"
-	}
+  "name": "pathofexile-dat",
+  "version": "13.0.0",
+  "type": "module",
+  "bin": "./dist/cli/run.js",
+  "exports": {
+    "./bundles.js": "./dist/bundles.js",
+    "./dat.js": "./dist/dat.js"
+  },
+  "files": ["dist/**/*"],
+  "license": "MIT",
+  "repository": {
+    "url": "https://github.com/SnosMe/poe-dat-viewer"
+  },
+  "dependencies": {
+    "ooz-wasm": "^2.0.0",
+    "pathofexile-dat-schema": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^5.2.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }


### PR DESCRIPTION
Currently when using the CLI tool to export tables you get this error:
```
Loading bundles index...
Loading schema for dat files
Schema has format not compatible with this package. Check for "pathofexile-dat" updates.
```

The latest schema version is `7` but a fresh install of the lib currently expects `6`, which is due to the version in the lib `^7.0.0` being restricted to minor and patch versions. Using `latest` instead would allow it to fetch the latest major version as well.

Merging this would mean that a fresh install of the lib becomes coupled to the latest published schema, which could cause issues if changes were needed in the lib to support changes in the schema. Will leave it up to you on whether you think this is an okay trade off or not.